### PR TITLE
Almost-dynamic zone update

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ dnserver --port 5053 my_zones.toml
 ```python
 from dnserver import DNSServer
 
-server = DNSServer('example_zones.toml', port=5053)
+server = DNSServer.from_toml('example_zones.toml', port=5053)
 server.start()
 assert server.is_running
 

--- a/dnserver/__init__.py
+++ b/dnserver/__init__.py
@@ -1,5 +1,6 @@
+from .load_records import Zone
 from .main import DNSServer
 from .version import VERSION
 
-__all__ = 'DNSServer', '__version__'
+__all__ = 'DNSServer', 'Zone', '__version__'
 __version__ = VERSION

--- a/dnserver/main.py
+++ b/dnserver/main.py
@@ -86,6 +86,7 @@ class Record:
 
 
 def resolve(request, handler, records):
+    records = [Record(zone) for zone in records.zones]
     type_name = QTYPE[request.q.qtype]
     reply = request.reply()
     for record in records:
@@ -108,7 +109,7 @@ def resolve(request, handler, records):
 
 class BaseResolver(LibBaseResolver):
     def __init__(self, records: Records):
-        self.records = [Record(zone) for zone in records.zones]
+        self.records = records
         super().__init__()
 
     def resolve(self, request, handler):
@@ -123,7 +124,7 @@ class BaseResolver(LibBaseResolver):
 
 class ProxyResolver(LibProxyResolver):
     def __init__(self, records: Records, upstream: str):
-        self.records = [Record(zone) for zone in records.zones]
+        self.records = records
         super().__init__(address=upstream, port=53, timeout=5)
 
     def resolve(self, request, handler):

--- a/dnserver/main.py
+++ b/dnserver/main.py
@@ -138,13 +138,13 @@ class ProxyResolver(LibProxyResolver):
 
 class DNSServer:
     def __init__(
-        self, records: Records | None, *, port: int | str | None = DEFAULT_PORT, upstream: str | None = DEFAULT_UPSTREAM
+        self, records: Records, *, port: int | str | None = DEFAULT_PORT, upstream: str | None = DEFAULT_UPSTREAM
     ):
         self.port: int = DEFAULT_PORT if port is None else int(port)
         self.upstream: str | None = upstream
         self.udp_server: LibDNSServer | None = None
         self.tcp_server: LibDNSServer | None = None
-        self.records: Records = records if records else Records(zones=[])
+        self.records: Records = records
 
     @classmethod
     def from_toml(

--- a/dnserver/main.py
+++ b/dnserver/main.py
@@ -176,7 +176,5 @@ class DNSServer:
     def is_running(self):
         return (self.udp_server and self.udp_server.isAlive()) or (self.tcp_server and self.tcp_server.isAlive())
 
-    def add_record(self, **kwargs):
-        zone = Zone(**kwargs)
+    def add_record(self, zone: Zone):
         self.records.zones.append(zone)
-        return zone

--- a/dnserver/main.py
+++ b/dnserver/main.py
@@ -4,7 +4,7 @@ import logging
 from datetime import datetime
 from pathlib import Path
 from textwrap import wrap
-from typing import Any
+from typing import Any, List
 
 from dnslib import QTYPE, RR, DNSLabel, dns
 from dnslib.proxy import ProxyResolver as LibProxyResolver
@@ -185,3 +185,6 @@ class DNSServer:
 
     def add_record(self, zone: Zone):
         self.records.zones.append(zone)
+
+    def set_records(self, zones: List[Zone]):
+        self.records.zones = zones

--- a/tests/test_dnsserver.py
+++ b/tests/test_dnsserver.py
@@ -170,9 +170,7 @@ def test_dynamic_zone_update(dns_server: DNSServer, dns_resolver: Resolver):
     with pytest.raises(dns.resolver.NXDOMAIN):
         dns_resolver('another-example.org', 'A')
 
-    dns_server.stop()
     dns_server.add_record(Zone(host='another-example.com', type='A', answer='2.3.4.5'))
-    dns_server.start()
 
     assert dns_resolver('example.com', 'A') == [
         {

--- a/tests/test_dnsserver.py
+++ b/tests/test_dnsserver.py
@@ -5,7 +5,7 @@ import pytest
 from dirty_equals import IsIP, IsPositive
 from dns.resolver import NoAnswer, Resolver as RawResolver
 
-from dnserver import DNSServer
+from dnserver import DNSServer, Zone
 
 Resolver = Callable[[str, str], List[Dict[str, Any]]]
 
@@ -171,7 +171,7 @@ def test_dynamic_zone_update(dns_server: DNSServer, dns_resolver: Resolver):
         dns_resolver('another-example.org', 'A')
 
     dns_server.stop()
-    dns_server.add_record(host='another-example.com', type='A', answer='2.3.4.5')
+    dns_server.add_record(Zone(host='another-example.com', type='A', answer='2.3.4.5'))
     dns_server.start()
 
     assert dns_resolver('example.com', 'A') == [

--- a/tests/test_dnsserver.py
+++ b/tests/test_dnsserver.py
@@ -37,7 +37,7 @@ def convert_answer(answer) -> Dict[str, Any]:
 def dns_server():
     port = 5053
 
-    server = DNSServer('example_zones.toml', port=port)
+    server = DNSServer.from_toml('example_zones.toml', port=port)
     server.start()
     assert server.is_running
     yield server
@@ -136,7 +136,7 @@ def test_soa_higher(dns_resolver: Resolver):
 def test_dns_server_without_upstream():
     port = 5054
 
-    server = DNSServer('example_zones.toml', port=port, upstream=None)
+    server = DNSServer.from_toml('example_zones.toml', port=port, upstream=None)
     server.start()
 
     resolver = RawResolver()

--- a/tests/test_dnsserver.py
+++ b/tests/test_dnsserver.py
@@ -184,3 +184,14 @@ def test_dynamic_zone_update(dns_server: DNSServer, dns_resolver: Resolver):
             'value': '2.3.4.5',
         },
     ]
+
+    dns_server.set_records([Zone(host='example.com', type='A', answer='4.5.6.7')])
+
+    assert dns_resolver('example.com', 'A') == [
+        {
+            'type': 'A',
+            'value': '4.5.6.7',
+        },
+    ]
+    with pytest.raises(dns.resolver.NXDOMAIN):
+        dns_resolver('another-example.org', 'A')


### PR DESCRIPTION
This follows the discussion on #14 

This patch adds a `DNSServer.add_record` method to dynamically add zones. As the DNS server runs in a thread, at the moment it is needed to reload the server after calling `add_record`.

If the approach is fine to you, I will submit a second PR where the record list will be shared between the threads. I am open to implementations ideas :)