### PR TITLE
Adding TTL support

### DIFF
--- a/dnserver/__init__.py
+++ b/dnserver/__init__.py
@@ -1,6 +1,6 @@
 from .load_records import Zone
-from .main import DNSServer
+from .main import DEFAULT_TTL, DEFAULT_TTL_NS_SOA, DNSServer
 from .version import VERSION
 
-__all__ = 'DNSServer', 'Zone', '__version__'
+__all__ = 'DNSServer', 'Zone', 'DEFAULT_TTL', 'DEFAULT_TTL_NS_SOA', '__version__'
 __version__ = VERSION

--- a/dnserver/load_records.py
+++ b/dnserver/load_records.py
@@ -4,7 +4,7 @@ import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 try:
     from typing import Literal
@@ -24,11 +24,11 @@ class Zone:
     host: str
     type: RecordType
     answer: str | list[str | int]
-    # TODO we could add ttl and other args here if someone wanted it
+    ttl: Optional[int] = None
 
     @classmethod
     def from_raw(cls, index: int, data: Any) -> Zone:
-        if not isinstance(data, dict) or data.keys() != {'host', 'type', 'answer'}:
+        if not isinstance(data, dict) or len([key for key in data.keys() if key in ['host', 'type', 'answer']]) != 3:
             raise ValueError(
                 f'Zone {index} is not a valid dict, must have keys "host", "type" and "answer", got {data!r}'
             )
@@ -49,7 +49,14 @@ class Zone:
                 f'Zone {index} is invalid, "answer" must be a string or list of strings and ints, got {data!r}'
             )
 
-        return cls(host, type_, answer)
+        ttl = None
+        if 'ttl' in data:
+            if isinstance(data['ttl'], int):
+                ttl = data['ttl']
+            else:
+                raise ValueError(f'Zone {index} is invalid, "ttl" must be an int, got {data["ttl"]}')
+
+        return cls(host, type_, answer, ttl)
 
 
 @dataclass

--- a/dnserver/main.py
+++ b/dnserver/main.py
@@ -12,7 +12,7 @@ from dnslib.server import BaseResolver as LibBaseResolver, DNSServer as LibDNSSe
 
 from .load_records import Records, Zone, load_records
 
-__all__ = 'DNSServer', 'logger'
+__all__ = 'DNSServer', 'logger', 'DEFAULT_TTL', 'DEFAULT_TTL_NS_SOA'
 
 SERIAL_NO = int((datetime.utcnow() - datetime(1970, 1, 1)).total_seconds())
 
@@ -42,6 +42,8 @@ TYPE_LOOKUP = {
 }
 DEFAULT_PORT = 53
 DEFAULT_UPSTREAM = '1.1.1.1'
+DEFAULT_TTL = 300
+DEFAULT_TTL_NS_SOA = 3600 * 24
 
 
 class Record:
@@ -64,9 +66,12 @@ class Record:
                 args = zone.answer
 
         if self._rtype in (QTYPE.NS, QTYPE.SOA):
-            ttl = 3600 * 24
+            ttl = DEFAULT_TTL_NS_SOA
         else:
-            ttl = 300
+            ttl = DEFAULT_TTL
+
+        if zone.ttl:
+            ttl = zone.ttl
 
         self.rr = RR(
             rname=self._rname,

--- a/example_zones.toml
+++ b/example_zones.toml
@@ -8,6 +8,7 @@ answer = '1.2.3.4'
 host = 'example.com'
 type = 'A'
 answer = '1.2.3.4'
+ttl = 1
 
 [[zones]]
 host = 'example.com'
@@ -18,6 +19,7 @@ answer = 'whatever.com'
 host = 'example.com'
 type = 'MX'
 answer = ['whatever.com.', 5]
+ttl = 3600
 
 [[zones]]
 host = 'example.com'

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -8,16 +8,16 @@ def test_load_records():
     records = load_records('example_zones.toml')
     assert records == Records(
         zones=[
-            Zone(host='example.com', type='A', answer='1.2.3.4'),
-            Zone(host='example.com', type='A', answer='1.2.3.4'),
-            Zone(host='example.com', type='CNAME', answer='whatever.com'),
-            Zone(host='example.com', type='MX', answer=['whatever.com.', 5]),
-            Zone(host='example.com', type='MX', answer=['mx2.whatever.com.', 10]),
-            Zone(host='example.com', type='MX', answer=['mx3.whatever.com.', 20]),
-            Zone(host='example.com', type='NS', answer='ns1.whatever.com.'),
-            Zone(host='example.com', type='NS', answer='ns2.whatever.com.'),
-            Zone(host='example.com', type='TXT', answer='hello this is some text'),
-            Zone(host='example.com', type='SOA', answer=['ns1.example.com', 'dns.example.com']),
+            Zone(host='example.com', type='A', answer='1.2.3.4', ttl=None),
+            Zone(host='example.com', type='A', answer='1.2.3.4', ttl=1),
+            Zone(host='example.com', type='CNAME', answer='whatever.com', ttl=None),
+            Zone(host='example.com', type='MX', answer=['whatever.com.', 5], ttl=3600),
+            Zone(host='example.com', type='MX', answer=['mx2.whatever.com.', 10], ttl=None),
+            Zone(host='example.com', type='MX', answer=['mx3.whatever.com.', 20], ttl=None),
+            Zone(host='example.com', type='NS', answer='ns1.whatever.com.', ttl=None),
+            Zone(host='example.com', type='NS', answer='ns2.whatever.com.', ttl=None),
+            Zone(host='example.com', type='TXT', answer='hello this is some text', ttl=None),
+            Zone(host='example.com', type='SOA', answer=['ns1.example.com', 'dns.example.com'], ttl=None),
             Zone(
                 host='testing.com',
                 type='TXT',
@@ -27,8 +27,9 @@ def test_load_records():
                     'Qbh9akm2bkNw5DC5a8Slp7j+eEVHkgV3k3oRhkPcrKyoPVvniDNH+Ln7DnSGC+Aw5Sp+fhu5aZmoODhhX5/1mANBgkqhkiG9w'
                     '0BAQEFAAOCAg8AMIICCgKCAgEA26JaFWZUed1qcBziAsqZ/LzTF2ASxJYuJ5sk'
                 ),
+                ttl=None
             ),
-            Zone(host='_caldavs._tcp.example.com', type='SRV', answer=[0, 1, 80, 'caldav']),
+            Zone(host='_caldavs._tcp.example.com', type='SRV', answer=[0, 1, 80, 'caldav'], ttl=None),
         ],
     )
 


### PR DESCRIPTION
I was using DNServer recently for testing out some Nginx proxy configurations. I needed to play with TTL and thought I'd have a go at pushing my the modifications I did for it upstream.

This change adds
- Adds an optional `ttl` attribute to `Zone`
- Two new constants `DEFAULT_TTL` and `DEFAULT_TTL_NS_SOA`