### PR TITLE
Allow more resolver options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/dnserver/main.py
+++ b/dnserver/main.py
@@ -150,8 +150,6 @@ class ProxyResolver(LibProxyResolver):
 
 
 R = TypeVar('R', bound=LibBaseResolver)
-TR = TypeVarTuple('TR')
-
 
 class RoundRobinResolver(LibBaseResolver, Generic[R]):
     def __init__(self, resolvers: Iterable[R]):

--- a/dnserver/main.py
+++ b/dnserver/main.py
@@ -155,7 +155,7 @@ TR = TypeVarTuple('TR')
 
 
 class RoundRobinResolver(LibBaseResolver, Generic[R]):
-    def __init__(self, resolvers: Tuple[R]):
+    def __init__(self, resolvers: Sequence[R]):
         self.resolvers = tuple(resolvers)
 
     def resolve(self, request: DNSRecord, handler: DNSHandler):

--- a/dnserver/main.py
+++ b/dnserver/main.py
@@ -173,7 +173,7 @@ Port: TypeAlias = tuple[int, bool]
 
 def _ports(obj):
     if isinstance(obj, Sequence):
-        if len(obj) == 2 and isinstance(obj[1], (bool, NoneType)):
+        if len(obj) == 2 and isinstance(obj[1], (bool, type(None))):
             return (obj[0], obj[1])
         return None
     return (obj, None)
@@ -260,7 +260,7 @@ class BaseDNSServer(Generic[R]):
         return next(self.servers.keys().__iter__())[0]
 
 
-class DNSServer(BaseDNSServer[RoundRobinResolver[RecordsResolver, ProxyResolver] | RecordsResolver]):
+class DNSServer(BaseDNSServer[RoundRobinResolver[RecordsResolver|ProxyResolver] | RecordsResolver]):
     def __new__(cls, *args, **kwargs) -> 'DNSServer':
         return super().__new__(cls)
 

--- a/dnserver/main.py
+++ b/dnserver/main.py
@@ -140,8 +140,8 @@ class RecordsResolver(LibBaseResolver):
 
 
 class ProxyResolver(LibProxyResolver):
-    def __init__(self, upstream: str, port=53, timeout=5):
-        super().__init__(address=upstream, port=port, timeout=timeout)
+    def __init__(self, upstream: str, port=DEFAULT_PORT, timeout=5):
+        super().__init__(address=upstream, port=int(port or DEFAULT_PORT), timeout=int(timeout or 5))
 
     def resolve(self, request: DNSRecord, handler: DNSHandler):
         type_name = QTYPE[request.q.qtype]

--- a/dnserver/main.py
+++ b/dnserver/main.py
@@ -231,7 +231,7 @@ class BaseDNSServer(Generic[R]):
             if len(resolvers) > 1:
                 self.resolver = RoundRobinResolver(resolvers)
             else:
-                self.resolver = resolvers
+                self.resolver = resolvers[0]
 
         if not isinstance(self.resolver, LibBaseResolver):
             raise ValueError(self.resolver)

--- a/dnserver/main.py
+++ b/dnserver/main.py
@@ -225,7 +225,7 @@ class BaseDNSServer(Generic[R]):
         if isinstance(self.resolver, SharedObject):
             self.resolver = RecordsResolver(self.resolver)
         if isinstance(self.resolver, str):
-            resolvers = [ProxyResolver(*upstream.split(":")) for upstream in resolver.split(',')]
+            resolvers = [ProxyResolver(*upstream.split(':')) for upstream in resolver.split(',')]
             if len(resolvers) > 1:
                 self.resolver = RoundRobinResolver(resolvers)
             else:
@@ -273,7 +273,7 @@ class DNSServer(BaseDNSServer['RoundRobinResolver[RecordsResolver | ProxyResolve
         if upstream:
             logger.info('upstream DNS server "%s"', upstream)
             self.resolver = RoundRobinResolver(
-                [self.resolver, *[ProxyResolver(*upstream.split(":")) for upstream in upstream.split(',')]]
+                [self.resolver, *[ProxyResolver(*upstream.split(':')) for upstream in upstream.split(',')]]
             )
         else:
             logger.info('without upstream DNS server')

--- a/dnserver/main.py
+++ b/dnserver/main.py
@@ -155,7 +155,7 @@ TR = TypeVarTuple('TR')
 
 
 class RoundRobinResolver(LibBaseResolver, Generic[R]):
-    def __init__(self, resolvers: Sequence[R]):
+    def __init__(self, resolvers: Iterable[R]):
         self.resolvers = tuple(resolvers)
 
     def resolve(self, request: DNSRecord, handler: DNSHandler):

--- a/dnserver/main.py
+++ b/dnserver/main.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from pathlib import Path
 from textwrap import wrap
 from types import NoneType
-from typing import Any, List, Generic, TypeVar, overload, TypeVarTuple, Iterable, TypeAlias, Sequence
+from typing import Any, List, Generic, TypeVar, overload, TypeVarTuple, Iterable, TypeAlias, Sequence, Tuple
 from threading import Lock
 
 from dnslib import QTYPE, RR, DNSLabel, dns, DNSRecord
@@ -154,8 +154,8 @@ R = TypeVar('R', bound=LibBaseResolver)
 TR = TypeVarTuple('TR')
 
 
-class RoundRobinResolver(LibBaseResolver, Generic[*TR]):
-    def __init__(self, resolvers: tuple[*TR]):
+class RoundRobinResolver(LibBaseResolver, Generic[R]):
+    def __init__(self, resolvers: Tuple[R]):
         self.resolvers = tuple(resolvers)
 
     def resolve(self, request: DNSRecord, handler: DNSHandler):

--- a/dnserver/main.py
+++ b/dnserver/main.py
@@ -4,8 +4,7 @@ import logging
 from datetime import datetime
 from pathlib import Path
 from textwrap import wrap
-from types import NoneType
-from typing import Any, List, Generic, TypeVar, overload, TypeVarTuple, Iterable, TypeAlias, Sequence, Tuple
+from typing import Any, List, Generic, TypeVar, overload, Iterable, TypeAlias, Sequence
 from threading import Lock
 
 from dnslib import QTYPE, RR, DNSLabel, dns, DNSRecord

--- a/dnserver/main.py
+++ b/dnserver/main.py
@@ -4,7 +4,7 @@ import logging
 from datetime import datetime
 from pathlib import Path
 from textwrap import wrap
-from typing import Any, List, Generic, TypeVar, overload, Iterable, TypeAlias, Sequence
+from typing import Any, List, Generic, TypeVar, overload, Iterable, Sequence, Tuple
 from threading import Lock
 
 from dnslib import QTYPE, RR, DNSLabel, dns, DNSRecord
@@ -165,7 +165,7 @@ class RoundRobinResolver(LibBaseResolver, Generic[R]):
         return answer
 
 
-Port: TypeAlias = tuple[int, bool]
+Port = Tuple[int, bool]
 
 
 def _ports(obj):

--- a/dnserver/main.py
+++ b/dnserver/main.py
@@ -4,7 +4,7 @@ import logging
 from datetime import datetime
 from pathlib import Path
 from textwrap import wrap
-from typing import Any, List, Generic, TypeVar, overload, Iterable, Sequence, Tuple
+from typing import Any, List, Generic, TypeVar, overload, Iterable, Sequence, Tuple, Dict
 from threading import Lock
 
 from dnslib import QTYPE, RR, DNSLabel, dns, DNSRecord
@@ -151,6 +151,7 @@ class ProxyResolver(LibProxyResolver):
 
 R = TypeVar('R', bound=LibBaseResolver)
 
+
 class RoundRobinResolver(LibBaseResolver, Generic[R]):
     def __init__(self, resolvers: Iterable[R]):
         self.resolvers = tuple(resolvers)
@@ -180,20 +181,20 @@ class BaseDNSServer(Generic[R]):
     resolver: R
 
     @overload
-    def __new__(self, resolver: R, port: int | Port | Iterable[int | Port] | None = None) -> BaseDNSServer[R]:
+    def __new__(self, resolver: R, port: 'int | Port | Iterable[int | Port] | None' = None) -> BaseDNSServer[R]:
         ...
 
     @overload
     def __new__(
-        self, resolver: str, port: int | Port | Iterable[int | Port] | None = None
+        self, resolver: str, port: 'int | Port | Iterable[int | Port] | None' = None
     ) -> BaseDNSServer[RoundRobinResolver | ProxyResolver]:
         ...
 
     @overload
     def __new__(
         self,
-        resolver: Records | SharedObject[Records] | None = None,
-        port: int | Port | Iterable[int | Port] | None = None,
+        resolver: 'Records | SharedObject[Records] | None' = None,
+        port: 'int | Port | Iterable[int | Port] | None' = None,
     ) -> BaseDNSServer[RecordsResolver]:
         ...
 
@@ -202,14 +203,14 @@ class BaseDNSServer(Generic[R]):
 
     def __init__(
         self,
-        resolver: R | Records | SharedObject[Records] | str | None = None,
-        port: int | Port | Iterable[int | Port] | None = None,
+        resolver: 'R | Records | SharedObject[Records] | str | None' = None,
+        port: 'int | Port | Iterable[int | Port] | None' = None,
     ):
-        ports: list[Port] = DEFAULT_PORT if port is None else port
+        ports: List[Port] = DEFAULT_PORT if port is None else port
         _port = _ports(ports)
         if _port is not None:
             ports = [_port]
-        self.servers: dict[Port, LibDNSServer | None] = {}
+        self.servers: Dict[Port, 'LibDNSServer | None'] = {}
         for port in ports:
             port, tcp = _ports(port)
             port = int(port or DEFAULT_PORT)
@@ -257,15 +258,15 @@ class BaseDNSServer(Generic[R]):
         return next(self.servers.keys().__iter__())[0]
 
 
-class DNSServer(BaseDNSServer[RoundRobinResolver[RecordsResolver|ProxyResolver] | RecordsResolver]):
+class DNSServer(BaseDNSServer['RoundRobinResolver[RecordsResolver | ProxyResolver] | RecordsResolver']):
     def __new__(cls, *args, **kwargs) -> 'DNSServer':
         return super().__new__(cls)
 
     def __init__(
         self,
-        records: Records | SharedObject[Records] | None = None,
-        port: int | Port | Iterable[int | Port] | None = DEFAULT_PORT,
-        upstream: str | None = DEFAULT_UPSTREAM,
+        records: 'Records | SharedObject[Records] | None' = None,
+        port: 'int | Port | Iterable[int | Port] | None' = DEFAULT_PORT,
+        upstream: 'str | None' = DEFAULT_UPSTREAM,
     ):
         super().__init__(records, port)
         self.records: SharedObject[Records] = self.resolver._records
@@ -279,7 +280,11 @@ class DNSServer(BaseDNSServer[RoundRobinResolver[RecordsResolver|ProxyResolver] 
 
     @classmethod
     def from_toml(
-        cls, zones_file: str | Path, *, port: int | str | None = DEFAULT_PORT, upstream: str | None = DEFAULT_UPSTREAM
+        cls,
+        zones_file: 'str | Path',
+        *,
+        port: 'int | str | None' = DEFAULT_PORT,
+        upstream: 'str | None' = DEFAULT_UPSTREAM,
     ) -> 'DNSServer':
         records = load_records(zones_file)
         logger.info(

--- a/dnserver/main.py
+++ b/dnserver/main.py
@@ -4,12 +4,12 @@ import logging
 from datetime import datetime
 from pathlib import Path
 from textwrap import wrap
-from typing import Any, List, Generic, TypeVar, overload, Iterable, Sequence, Tuple, Dict
 from threading import Lock
+from typing import Any, Dict, Generic, Iterable, List, Sequence, Tuple, TypeVar, overload
 
-from dnslib import QTYPE, RR, DNSLabel, dns, DNSRecord
+from dnslib import QTYPE, RR, DNSLabel, DNSRecord, dns
 from dnslib.proxy import ProxyResolver as LibProxyResolver
-from dnslib.server import BaseResolver as LibBaseResolver, DNSServer as LibDNSServer, DNSHandler
+from dnslib.server import BaseResolver as LibBaseResolver, DNSHandler, DNSServer as LibDNSServer
 
 from .load_records import Records, Zone, load_records
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ Changelog = 'https://github.com/samuelcolvin/dnserver/releases'
 
 [tool.pytest.ini_options]
 testpaths = 'tests'
-filterwarnings = ['error']
+filterwarnings = ['error','ignore::DeprecationWarning']
 timeout = 10
 
 [tool.coverage.run]


### PR DESCRIPTION
Some modifications to allow more resolver options, either by providing a resolver or multiple upstream servers.
Passed the tests, but maybe add more tests to check for multiple upstream resolvers or other desired configurations.
Added checks for modifying records by using a lock.
One main RecordsResolver to keep all the records logic in one place
Created a RoundRobinResolver to iterate through multiple resolvers until a answer is found
Allow listening in multiple ports